### PR TITLE
Lisätty vakiot etärepoon

### DIFF
--- a/tietovisa/lib/utils/vakiot.dart
+++ b/tietovisa/lib/utils/vakiot.dart
@@ -1,0 +1,2 @@
+// Vakiossa määritellään Trivia API:n perus-URL, jota käytetään palvelupyynnöissä.
+const String apiBaseUrl = "https://opentdb.com"; // Trivia API:n perusosoite.


### PR DESCRIPTION
Trivia API:n perus-URL, jota käytetään palvelupyynnöissä